### PR TITLE
Minor fix to README for incorrect config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Sample pillar with custom logging
         listen:
           https-in:
             binds:
-              address: 0.0.0.0
+            - address: 0.0.0.0
               port: 443
             servers:
             - name: server1


### PR DESCRIPTION
Small update to README to fix one of the examples having the wrong syntax.